### PR TITLE
add crackmapexec for standard installation

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -48,5 +48,6 @@
   - include_tasks: tasks/install_wkhtmltopdf.yml
   - include_tasks: tasks/install_xsstrike.yml
   - include_tasks: tasks/install_zauberfeder.yml
+  - include_tasks: tasks/install_crackmapexec.yml
 
   - include_tasks: tasks/add_aliases.yml

--- a/tasks/install_crackmapexec.yml
+++ b/tasks/install_crackmapexec.yml
@@ -1,0 +1,6 @@
+---
+# https://github.com/byt3bl33d3r/CrackMapExec
+- name: Ensure crackmapexec is installed (Kali).
+  apt:
+    name: "crackmapexec"
+    state: present


### PR DESCRIPTION
Requesting crackmapexec be added to the standard playbook.  Crackmapexec is an excellent pentesting tool for pentesters and OSCP/HTB users.