### PR TITLE
Quick and dirty fix for #13. 

### DIFF
--- a/tasks/install_custom_samba.yml
+++ b/tasks/install_custom_samba.yml
@@ -103,7 +103,7 @@
     - nettle-dev
     - patch
     - perl
-    - perl-modules
+    - perl-modules-5.32
     - pkg-config
     - procps
     - psmisc


### PR DESCRIPTION
As ansible does not allow for wildcard on package names this will need to be updated or reworked (to a special "shell:" segment) at a later date as the "perl-modules-5.*" package updates. 